### PR TITLE
Implement Telegram word game bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,442 @@
+import asyncio
+import json
+import os
+import random
+import secrets
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional, Set, List
+
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import JSONResponse
+from telegram import (BotCommand, InlineKeyboardButton, InlineKeyboardMarkup,
+                      Update, ForceReply)
+from telegram.ext import (Application, CallbackContext, CallbackQueryHandler,
+                          CommandHandler, MessageHandler, ContextTypes,
+                          filters)
+
+# --- Utilities --------------------------------------------------------------
+
+DICT_PATH = Path(__file__).with_name("nouns_ru_pymorphy2_yaspeller.jsonl")
+
+
+def normalize_word(word: str) -> str:
+    """Normalize words: lowercase and replace ё with е."""
+    return word.lower().replace("ё", "е")
+
+
+# Load dictionary at startup
+DICT: Set[str] = set()
+for line in DICT_PATH.read_text(encoding="utf-8").splitlines():
+    try:
+        data = json.loads(line)
+        DICT.add(normalize_word(data["word"]))
+    except Exception:
+        continue
+
+
+def is_cyrillic(word: str) -> bool:
+    return all("а" <= ch <= "я" or ch == "ё" for ch in word.lower())
+
+
+def can_make(word: str, letters: Counter) -> bool:
+    c = Counter(word)
+    for k, v in c.items():
+        if letters.get(k, 0) < v:
+            return False
+    return True
+
+
+# --- Data classes ----------------------------------------------------------
+
+@dataclass
+class Player:
+    user_id: int
+    name: str = ""
+    words: List[str] = field(default_factory=list)
+    points: int = 0
+
+
+@dataclass
+class GameState:
+    host_id: int
+    time_limit: int = 3
+    base_word: str = ""
+    letters: Counter = field(default_factory=Counter)
+    players: Dict[int, Player] = field(default_factory=dict)
+    used_words: Set[str] = field(default_factory=set)
+    status: str = "config"  # config | waiting | running | finished
+    jobs: Dict[str, any] = field(default_factory=dict)
+
+
+ACTIVE_GAMES: Dict[int, GameState] = {}
+JOIN_CODES: Dict[str, int] = {}
+
+
+# --- FastAPI & PTB integration ---------------------------------------------
+
+app = FastAPI()
+APPLICATION: Optional[Application] = None
+BOT_USERNAME: Optional[str] = None
+
+ADMIN_ID = int(os.environ.get("ADMIN_ID", "0"))
+TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
+PUBLIC_URL = os.environ.get("PUBLIC_URL")
+WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", secrets.token_hex())
+WEBHOOK_PATH = os.environ.get("WEBHOOK_PATH", "/webhook")
+
+
+async def start_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    code = context.args[0] if context.args else None
+    if code and code in JOIN_CODES:
+        context.user_data["join_chat"] = JOIN_CODES[code]
+        await update.message.reply_text(
+            "Вы можете присоединиться к игре. Зайдите в чат и нажмите кнопку 'Присоединиться'.")
+    else:
+        await update.message.reply_text("Привет! Используйте /newgame в групповом чате.")
+
+
+async def request_name(user_id: int, chat_id: int, context: CallbackContext) -> None:
+    await context.bot.send_message(
+        chat_id=chat_id,
+        text="Введите ваше имя",
+        reply_markup=ForceReply(selective=True),
+    )
+
+
+async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat_id = update.effective_chat.id
+    user_id = update.effective_user.id
+
+    game = ACTIVE_GAMES.get(chat_id)
+    if game and game.status in {"waiting", "running"}:
+        await update.message.reply_text("Игра уже запущена.")
+        return
+
+    game = GameState(host_id=user_id)
+    ACTIVE_GAMES[chat_id] = game
+    game.players[user_id] = Player(user_id=user_id)
+
+    await request_name(user_id, chat_id, context)
+
+    buttons = [
+        [InlineKeyboardButton("3 минуты", callback_data="time_3"),
+         InlineKeyboardButton("5 минут", callback_data="time_5")]
+    ]
+    if user_id == ADMIN_ID:
+        buttons.append([InlineKeyboardButton("[адм.] Тест", callback_data="adm_test")])
+
+    await update.message.reply_text(
+        "Выберите длительность игры:",
+        reply_markup=InlineKeyboardMarkup(buttons),
+    )
+
+
+async def handle_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat_id = update.effective_chat.id
+    user_id = update.effective_user.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game:
+        return
+    player = game.players.get(user_id)
+    if player and not player.name:
+        player.name = update.message.text.strip()
+        await update.message.reply_text(f"Имя установлено: {player.name}")
+
+
+async def time_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    chat_id = query.message.chat.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or query.from_user.id != game.host_id:
+        return
+    if query.data.startswith("time_"):
+        game.time_limit = int(query.data.split("_")[1])
+        game.status = "waiting"
+        code = secrets.token_urlsafe(8)
+        JOIN_CODES[code] = chat_id
+        await query.edit_message_text(
+            f"Игра создана. Присоединяйтесь: /join или ссылка https://t.me/{BOT_USERNAME}?start={code}")
+        await query.message.reply_text(
+            "Нажмите 'Присоединиться' чтобы вступить в игру",
+            reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("Присоединиться", callback_data="join")]])
+        )
+    elif query.data == "adm_test" and query.from_user.id == ADMIN_ID:
+        game.time_limit = 3
+        game.status = "running"
+        game.base_word = random.choice([w for w in DICT if len(w) >= 8])
+        game.letters = Counter(game.base_word)
+        bot_player = Player(user_id=0, name="Bot")
+        game.players[0] = bot_player
+        await query.edit_message_text("Тестовая игра началась")
+        await start_game(chat_id, context)
+        context.job_queue.run_repeating(bot_move, 30, chat_id=chat_id, name=f"bot_{chat_id}")
+
+
+async def join_button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    chat_id = query.message.chat.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game:
+        return
+    user_id = query.from_user.id
+    if user_id not in game.players:
+        game.players[user_id] = Player(user_id=user_id)
+        await query.message.reply_text("Добро пожаловать! Введите ваше имя:", reply_markup=ForceReply(selective=True))
+    else:
+        await query.message.reply_text("Вы уже в игре")
+
+    if len(game.players) >= 2 and game.status == "waiting" and user_id == game.host_id:
+        await query.message.reply_text(
+            "Выберите базовое слово:",
+            reply_markup=InlineKeyboardMarkup([
+                [InlineKeyboardButton("Ввести", callback_data="base_manual"),
+                 InlineKeyboardButton("Случайное", callback_data="base_random")]
+            ])
+        )
+
+
+async def base_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    chat_id = query.message.chat.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or query.from_user.id != game.host_id:
+        return
+
+    if query.data == "base_manual":
+        await query.message.reply_text("Введите базовое слово (>=8 букв):", reply_markup=ForceReply())
+    elif query.data == "base_random":
+        candidates = [w for w in DICT if len(w) >= 8]
+        if game.time_limit >= 5:
+            candidates = [w for w in candidates if len(w) >= 10]
+        if len(game.players) >= 3:
+            candidates = [w for w in candidates if len(w) >= 9]
+        words = random.sample(candidates, 3)
+        buttons = [[InlineKeyboardButton(w, callback_data=f"pick_{w}")] for w in words]
+        await query.message.reply_text(
+            "Выберите слово:",
+            reply_markup=InlineKeyboardMarkup(buttons),
+        )
+        context.job_queue.run_once(finish_random, 5, chat_id=chat_id, data=words, name=f"rand_{chat_id}")
+
+    elif query.data.startswith("pick_"):
+        word = query.data.split("_", 1)[1]
+        if "rand" in game.jobs:
+            job = game.jobs.pop("rand")
+            job.schedule_removal()
+        await set_base_word(chat_id, word, context)
+
+
+async def finish_random(context: CallbackContext) -> None:
+    chat_id = context.job.chat_id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or game.base_word:
+        return
+    word = random.choice(context.job.data)
+    await set_base_word(chat_id, word, context)
+
+
+def schedule_jobs(chat_id: int, context: CallbackContext, game: GameState) -> None:
+    warn = context.job_queue.run_once(warn_time, (game.time_limit - 1) * 60, chat_id=chat_id, name=f"warn_{chat_id}")
+    end = context.job_queue.run_once(end_game, game.time_limit * 60, chat_id=chat_id, name=f"end_{chat_id}")
+    game.jobs["warn"] = warn
+    game.jobs["end"] = end
+
+
+async def start_button(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    chat_id = query.message.chat.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or query.from_user.id != game.host_id or not game.base_word:
+        return
+    await query.edit_message_text("Игра начинается!")
+    await start_game(chat_id, context)
+
+
+async def start_game(chat_id: int, context: CallbackContext) -> None:
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game:
+        return
+    game.status = "running"
+    await context.bot.send_message(chat_id, f"Исходное слово: {game.base_word.upper()}")
+    schedule_jobs(chat_id, context, game)
+
+
+async def set_base_word(chat_id: int, word: str, context: CallbackContext) -> None:
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game:
+        return
+    game.base_word = normalize_word(word)
+    game.letters = Counter(game.base_word)
+    await context.bot.send_message(chat_id, f"Выбрано слово: {game.base_word}")
+    await context.bot.send_message(chat_id, "Нажмите Старт, когда будете готовы", reply_markup=InlineKeyboardMarkup([[InlineKeyboardButton("Старт", callback_data="start")]]))
+
+
+async def warn_time(context: CallbackContext) -> None:
+    await context.bot.send_message(context.job.chat_id, "Осталась 1 минута!")
+
+
+async def end_game(context: CallbackContext) -> None:
+    chat_id = context.job.chat_id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game:
+        return
+    game.status = "finished"
+    scores = [(p.name or str(uid), p.points) for uid, p in game.players.items()]
+    scores.sort(key=lambda x: x[1], reverse=True)
+    lines = [f"{name}: {pts}" for name, pts in scores]
+    await context.bot.send_message(chat_id, "Игра окончена!\n" + "\n".join(lines))
+    await context.bot.send_message(chat_id, "Новая игра с теми же участниками?", reply_markup=InlineKeyboardMarkup([
+        [InlineKeyboardButton("Да", callback_data="restart_yes"), InlineKeyboardButton("Нет", callback_data="restart_no")]
+    ]))
+
+
+def reset_game(game: GameState) -> None:
+    for p in game.players.values():
+        p.words.clear()
+        p.points = 0
+    game.used_words.clear()
+    game.base_word = ""
+    game.letters.clear()
+    game.status = "config"
+    for job in game.jobs.values():
+        job.schedule_removal()
+    game.jobs.clear()
+
+
+async def restart_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    chat_id = query.message.chat.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game:
+        return
+    if query.data == "restart_yes":
+        reset_game(game)
+        await query.edit_message_text("Игра перезапущена. Выберите длительность:")
+        buttons = [[InlineKeyboardButton("3 минуты", callback_data="time_3"), InlineKeyboardButton("5 минут", callback_data="time_5")]]
+        if game.host_id == ADMIN_ID:
+            buttons.append([InlineKeyboardButton("[адм.] Тест", callback_data="adm_test")])
+        await query.message.reply_text("Выберите длительность игры:", reply_markup=InlineKeyboardMarkup(buttons))
+    else:
+        del ACTIVE_GAMES[chat_id]
+        await query.edit_message_text("Игра завершена. Для новой игры с новыми участниками нажмите /start")
+
+
+async def word_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat_id = update.effective_chat.id
+    user_id = update.effective_user.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or game.status != "running":
+        return
+    player = game.players.get(user_id)
+    if not player:
+        return
+    words = [normalize_word(w) for w in update.message.text.split()]
+    responses = []
+    for w in words:
+        if not is_cyrillic(w) or len(w) < 3:
+            continue
+        if w in game.used_words:
+            continue
+        if not can_make(w, game.letters):
+            continue
+        if w not in DICT:
+            continue
+        game.used_words.add(w)
+        player.words.append(w)
+        pts = 2 if len(w) >= 6 else 1
+        player.points += pts
+        responses.append(f"{w} (+{pts})")
+    if responses:
+        await update.message.reply_text("Зачтено: " + ", ".join(responses))
+
+
+async def manual_base_word(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat_id = update.effective_chat.id
+    user_id = update.effective_user.id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or user_id != game.host_id or game.base_word:
+        return
+    word = normalize_word(update.message.text)
+    if len(word) < 8 or word not in DICT:
+        await update.message.reply_text("Неверное слово")
+        return
+    await set_base_word(chat_id, word, context)
+
+
+async def bot_move(context: CallbackContext) -> None:
+    chat_id = context.job.chat_id
+    game = ACTIVE_GAMES.get(chat_id)
+    if not game or game.status != "running":
+        return
+    available = [w for w in DICT if len(w) >= 3 and can_make(w, game.letters) and w not in game.used_words]
+    if not available:
+        return
+    word = random.choice(available)
+    update = Update(update_id=0, message=None)
+    bot_player = game.players.get(0)
+    if bot_player:
+        bot_player.words.append(word)
+        pts = 2 if len(word) >= 6 else 1
+        bot_player.points += pts
+        game.used_words.add(word)
+        await context.bot.send_message(chat_id, f"Bot: {word}")
+
+
+async def webhook_check(context: CallbackContext) -> None:
+    info = await context.bot.get_webhook_info()
+    if not info.url:
+        print("Webhook missing")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    global APPLICATION, BOT_USERNAME
+    APPLICATION = Application.builder().token(TOKEN).build()
+    BOT_USERNAME = (await APPLICATION.bot.get_me()).username
+    APPLICATION.add_handler(CommandHandler("start", start_cmd))
+    APPLICATION.add_handler(CommandHandler("newgame", newgame))
+    APPLICATION.add_handler(MessageHandler(filters.REPLY & filters.TEXT & (~filters.COMMAND), handle_name))
+    APPLICATION.add_handler(CallbackQueryHandler(time_selected, pattern="^(time_|adm_test)"))
+    APPLICATION.add_handler(CallbackQueryHandler(join_button, pattern="^join$"))
+    APPLICATION.add_handler(CallbackQueryHandler(base_choice, pattern="^(base_|pick_)", block=False))
+    APPLICATION.add_handler(CallbackQueryHandler(start_button, pattern="^start$"))
+    APPLICATION.add_handler(CallbackQueryHandler(restart_handler, pattern="^restart_"))
+    APPLICATION.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), manual_base_word))
+    APPLICATION.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), word_message))
+    APPLICATION.job_queue.run_repeating(webhook_check, 600, name="webhook_check")
+
+    if PUBLIC_URL:
+        webhook_url = f"{PUBLIC_URL.rstrip('/')}{WEBHOOK_PATH}"
+        info = await APPLICATION.bot.get_webhook_info()
+        if info.url != webhook_url:
+            await APPLICATION.bot.set_webhook(url=webhook_url, secret_token=WEBHOOK_SECRET)
+
+
+@app.post(WEBHOOK_PATH)
+async def telegram_webhook(request: Request) -> JSONResponse:
+    if request.headers.get("X-Telegram-Bot-Api-Secret-Token") != WEBHOOK_SECRET:
+        raise HTTPException(status_code=403, detail="Invalid secret")
+    data = await request.json()
+    update = Update.de_json(data, APPLICATION.bot)
+    await APPLICATION.process_update(update)
+    return JSONResponse({"ok": True})
+
+
+@app.get("/set_webhook")
+async def set_webhook() -> JSONResponse:
+    webhook_url = f"{PUBLIC_URL.rstrip('/')}{WEBHOOK_PATH}"
+    await APPLICATION.bot.set_webhook(url=webhook_url, secret_token=WEBHOOK_SECRET)
+    return JSONResponse({"url": webhook_url})
+
+
+@app.get("/healthz")
+async def healthz() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+


### PR DESCRIPTION
## Summary
- Implement FastAPI + python-telegram-bot web service for word game “Составь слово!”
- Add game state management, random/manual base word selection, scoring and restart logic
- Provide webhook, healthcheck and auto webhook registration with periodic checks

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6c115348483269ec0aa189da86a8b