### PR TITLE
Limit join command to five players

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,6 +262,9 @@ async def join_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
     user_id = update.effective_user.id
     if user_id not in game.players:
+        if len(game.players) >= 5:
+            await reply_game_message(update.message, context, "Лобби заполнено")
+            return
         game.players[user_id] = Player(user_id=user_id)
         await reply_game_message(
             update.message,


### PR DESCRIPTION
## Summary
- prevent new players joining when lobby already has five players
- send "Лобби заполнено" message if lobby is full

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6df2eece8832697ba2ddbbbe8dfb2