### PR TITLE
Prompt time selection after restart

### DIFF
--- a/app.py
+++ b/app.py
@@ -538,9 +538,21 @@ async def restart_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
     if query.data == "restart_yes":
         reset_game(game)
-        game.status = "waiting"
         await query.edit_message_text("Игра перезапущена.")
-        await maybe_show_base_options(chat_id, context)
+        buttons = [
+            [
+                InlineKeyboardButton("3 минуты", callback_data="time_3"),
+                InlineKeyboardButton("5 минут", callback_data="time_5"),
+            ]
+        ]
+        if query.from_user.id == ADMIN_ID:
+            buttons.append([InlineKeyboardButton("[адм.] Тест", callback_data="adm_test")])
+        await reply_game_message(
+            query.message,
+            context,
+            "Выберите длительность игры:",
+            reply_markup=InlineKeyboardMarkup(buttons),
+        )
     else:
         del ACTIVE_GAMES[chat_id]
         await query.edit_message_text("Игра завершена. Для новой игры с новыми участниками нажмите /start")


### PR DESCRIPTION
## Summary
- Ask players to choose game duration after restart
- Include admin test button when applicable

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e12628108326aee4c77140dc56f4