### PR TITLE
Show instruction above base word button

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,7 +91,7 @@ async def refresh_base_button(chat_id: int, context: CallbackContext) -> None:
     game = ACTIVE_GAMES.get(chat_id)
     if not game or game.status != "running" or not game.base_word:
         return
-    text = "Собирайте слова из букв базового слова:" if not game.base_msg_id else "\u2060"
+    text = "Собирайте слова из букв базового слова:"
     if game.base_msg_id:
         try:
             await context.bot.delete_message(chat_id, game.base_msg_id)


### PR DESCRIPTION
## Summary
- Always send visible instruction text when refreshing the base word button

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b715c2dab8832697c9e7273bed6dd2