### PR TITLE
Track join chat for initiator in newgame

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,6 +178,7 @@ async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     game = GameState(host_id=user_id)
     ACTIVE_GAMES[chat_id] = game
     game.players[user_id] = Player(user_id=user_id)
+    context.user_data["join_chat"] = chat_id
 
     await request_name(user_id, chat_id, context)
 


### PR DESCRIPTION
## Summary
- Store chat ID in `context.user_data['join_chat']` when initializing a new game so initiator can join later

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b73f794c0083268e3e0839a2c25e56