### PR TITLE
Add optional public word confirmations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,4 +260,5 @@ uvicorn[standard]>=0.30
 - `PUBLIC_URL` — публичный HTTPS-URL (например, `https://<имя>.onrender.com`)  
 - `WEBHOOK_SECRET` — длинная случайная строка 
 - `WEBHOOK_PATH` — (опц.) путь вебхука, по умолчанию `/webhook`
+- `WORD_CONFIRM_IN_CHAT` — (опц.) `1` чтобы дублировать подтверждение слова в групповой чат
 

--- a/app.py
+++ b/app.py
@@ -142,6 +142,7 @@ TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
 PUBLIC_URL = os.environ.get("PUBLIC_URL")
 WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", secrets.token_hex())
 WEBHOOK_PATH = os.environ.get("WEBHOOK_PATH", "/webhook")
+WORD_CONFIRM_IN_CHAT = os.environ.get("WORD_CONFIRM_IN_CHAT") == "1"
 
 
 async def start_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -682,6 +683,14 @@ async def word_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     chat_id,
                     context,
                     f"{mention} напишите мне в личные сообщения (/start), чтобы получать мгновенную обратную связь.",
+                    parse_mode="HTML",
+                )
+        else:
+            if WORD_CONFIRM_IN_CHAT:
+                await send_game_message(
+                    chat_id,
+                    context,
+                    f"{mention} {text}",
                     parse_mode="HTML",
                 )
 


### PR DESCRIPTION
## Summary
- add `WORD_CONFIRM_IN_CHAT` env flag to also post word feedback in group chats
- document new environment variable in AGENTS instructions

## Testing
- `python3 -m py_compile app.py`
- `python3 -m pytest` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_68b74341b5b48326ad91a6666011f5b2