### PR TITLE
Avoid broadcasting word feedback to other players

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,5 @@ uvicorn[standard]>=0.30
 - `ADMIN_ID` — Telegram ID администратора  
 - `TELEGRAM_BOT_TOKEN` — токен от @BotFather  
 - `PUBLIC_URL` — публичный HTTPS-URL  
-- `WEBHOOK_SECRET` — длинная случайная строка  
-- `WEBHOOK_PATH` — (опц.) путь вебхука, по умолчанию `/webhook`  
-- `WORD_CONFIRM_IN_CHAT` — (опц.) `1`, чтобы дублировать подтверждение слова в личках у всех игроков  
+- `WEBHOOK_SECRET` — длинная случайная строка
+- `WEBHOOK_PATH` — (опц.) путь вебхука, по умолчанию `/webhook`


### PR DESCRIPTION
## Summary
- Stop sending word validation results to opponents; feedback now goes only to the submitting player
- Drop unused WORD_CONFIRM_IN_CHAT environment variable

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc0491da448326980eef65adc58b2b