### PR TITLE
Expose app module and fix dictionary paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
    ```
    uvicorn app:app --host 0.0.0.0 --port 8000
    ```
+   (корневой `app.py` лишь переэкспортирует `compose_word_game.word_game_app:app`)
 4. Для вебхука нужен туннель (ngrok / cloudflared).
    Установите `PUBLIC_URL` и вызовите:
    ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,1 @@
+from compose_word_game.word_game_app import app

--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -39,8 +39,9 @@ from telegram.error import TelegramError
 
 # --- Utilities --------------------------------------------------------------
 
-DICT_PATH = Path(__file__).with_name("nouns_ru_pymorphy2_yaspeller.jsonl")
-WHITELIST_PATH = Path(__file__).with_name("whitelist.jsonl")
+BASE_DIR = Path(__file__).resolve().parent.parent
+DICT_PATH = BASE_DIR / "nouns_ru_pymorphy2_yaspeller.jsonl"
+WHITELIST_PATH = BASE_DIR / "whitelist.jsonl"
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(level=LOG_LEVEL)


### PR DESCRIPTION
## Summary
- add a top-level `app.py` that re-exports the FastAPI application
- correct dictionary and whitelist file paths in `word_game_app`
- document the re-exported app in the quick start instructions

## Testing
- `python -m py_compile app.py compose_word_game/word_game_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc8129381c83268d3b90a859ad53b9