### PR TITLE
Add startup logging for word handler

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -904,8 +904,14 @@ async def restart_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 async def word_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     start_ts = perf_counter()
-    # подробный входной лог
+    # временный INFO-лог для подтверждения запуска обработчика
     try:
+        logger.info(
+            "word_message START chat_id=%s user=%s text=%r",
+            update.effective_chat.id if update.effective_chat else None,
+            update.effective_user.id if update.effective_user else None,
+            update.effective_message.text if update.effective_message else None,
+        )
         logger.debug(
             "word_message ENTER chat_id=%s type=%s thread=%s user=%s text=%r",
             update.effective_chat.id if update.effective_chat else None,


### PR DESCRIPTION
## Summary
- add temporary INFO log at the start of `word_message`

## Testing
- `python -m py_compile compose_word_game/word_game_app.py`
- `pytest`
- `TELEGRAM_BOT_TOKEN=1 ADMIN_ID=1 uvicorn app:app --host 127.0.0.1 --port 8000` *(fails: httpx ProxyError 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc936e7e908326b28c91190f831e61