### PR TITLE
Prioritize word_message handler

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1193,18 +1193,20 @@ async def on_startup() -> None:
     # 2) Поднять основной обработчик слов выше прочих текстовых; он неблокирующий
     APPLICATION.add_handler(
         MessageHandler(filters.TEXT & (~filters.COMMAND), word_message, block=False),
-        group=0
+        group=1,
     )
     # Остальные текстовые — ниже
     APPLICATION.add_handler(
-        MessageHandler(filters.TEXT & (~filters.COMMAND), manual_base_word, block=False)
+        MessageHandler(filters.TEXT & (~filters.COMMAND), manual_base_word, block=False),
+        group=2,
     )
     APPLICATION.add_handler(
         MessageHandler(
             filters.ChatType.PRIVATE & ~filters.COMMAND,
             handle_submission,
             block=False,
-        )
+        ),
+        group=2,
     )
     # (раньше мы регистрировали word_message здесь; перенесено выше)
     


### PR DESCRIPTION
## Summary
- Ensure `word_message` handler runs in group 1
- Move `manual_base_word` and `handle_submission` handlers to group 2 so they run after `word_message`

## Testing
- `pytest`
- `python -m py_compile compose_word_game/word_game_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc965c57e08326a2579b752ff56b92