### PR TITLE
Skip invite step when existing players

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -389,8 +389,17 @@ async def time_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if query.data.startswith("time_"):
         game.time_limit = int(query.data.split("_")[1])
         game.status = "waiting"
-        code = secrets.token_urlsafe(8)
-        JOIN_CODES[code] = game.game_id
+        if len(game.players) >= 2 and all(p.name for p in game.players.values()):
+            code = next((c for c, gid in JOIN_CODES.items() if gid == game.game_id), None)
+            if code:
+                JOIN_CODES.pop(code, None)
+            await query.edit_message_text("Длительность установлена")
+            await maybe_show_base_options(chat_id, thread_id, context, game)
+            return
+        code = next((c for c, gid in JOIN_CODES.items() if gid == game.game_id), None)
+        if not code:
+            code = secrets.token_urlsafe(8)
+            JOIN_CODES[code] = game.game_id
         await query.edit_message_text("Игра создана. Пригласите участников.")
         keyboard = ReplyKeyboardMarkup(
             [


### PR DESCRIPTION
## Summary
- Skip invitation step and show base-word selection when restart includes all named players
- Avoid regenerating join codes when invites are skipped to block new players

## Testing
- `python -m py_compile compose_word_game/word_game_app.py`
- `python - <<'PY'
import asyncio
from types import SimpleNamespace
import compose_word_game.word_game_app as app

async def run_test():
    game = app.GameState(host_id=1, game_id='gid')
    game.players[1] = app.Player(user_id=1, name='Host')
    game.players[2] = app.Player(user_id=2, name='P2')
    game.player_chats = {1:1, 2:2}
    app.ACTIVE_GAMES[game.game_id] = game

    called = {}
    async def stub_maybe(chat_id, thread_id, context, game_obj):
        called['maybe'] = (chat_id, thread_id, game_obj.game_id)
    app.maybe_show_base_options = stub_maybe

    class DummyQuery:
        def __init__(self):
            self.data = 'time_3'
            self.message = SimpleNamespace(chat=SimpleNamespace(id=1, type='private'), message_thread_id=None)
            self.from_user = SimpleNamespace(id=1)
        async def answer(self):
            pass
        async def edit_message_text(self, text):
            called['text'] = text
    update = SimpleNamespace(callback_query=DummyQuery())
    context = SimpleNamespace(user_data={})
    await app.time_selected(update, context)
    print('maybe_call', called.get('maybe'))
    print('text', called.get('text'))
    print('join_codes', app.JOIN_CODES)

asyncio.run(run_test())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bc9c234f1883268b47123947b010a1