### PR TITLE
Start countdown immediately for base word selection

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -611,6 +611,7 @@ async def base_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             job = context.job_queue.run_repeating(
                 countdown,
                 interval=1,
+                first=0,
                 chat_id=cid,
                 data={
                     "thread_id": thread,


### PR DESCRIPTION
## Summary
- start the word selection countdown immediately by invoking `run_repeating` with `first=0`

## Testing
- `python -m py_compile compose_word_game/word_game_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd3046251c83269677006ef4737153