### PR TITLE
Refine start flow for word games

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -271,7 +271,7 @@ async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     game = create_dm_game(user.id)
     chat_id = update.effective_chat.id
     if update.message:
-        await reply_game_message(update.message, context, f"Игра #{game.game_id} создана")
+        await reply_game_message(update.message, context, "Игра создана")
     await request_name(user.id, chat_id, context)
 
 


### PR DESCRIPTION
## Summary
- Simplify Grebeshok game creation: request name first, show invite options and time menu after
- Hide join code in Compose Word Game startup message

## Testing
- `pytest`
- `python -m py_compile grebeshok_game/grebeshok_app.py compose_word_game/word_game_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd321085088326bec3bfcd63551fff