### PR TITLE
Keep invite keyboard persistent after time selection

### DIFF
--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -385,7 +385,7 @@ async def time_selected(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
                 [KeyboardButton("Создать ссылку")],
             ]
             markup = ReplyKeyboardMarkup(
-                buttons, resize_keyboard=True, one_time_keyboard=True
+                buttons, resize_keyboard=True, one_time_keyboard=False
             )
             await context.bot.send_message(
                 chat.id, "Пригласите игроков:", reply_markup=markup


### PR DESCRIPTION
## Summary
- Keep invite keyboard visible after choosing game duration by disabling one-time keyboard flag

## Testing
- `python -m py_compile grebeshok_game/grebeshok_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd81f8e4308326936fc1f11d7bf914