### PR TITLE
refactor: unpin base letters

### DIFF
--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -692,6 +692,7 @@ async def start_round(game: GameState, context: CallbackContext) -> None:
     for uid in list(game.players.keys()):
         chat_id = game.player_chats.get(uid)
         if chat_id:
+            await context.bot.unpin_all_chat_messages(chat_id)
             await refresh_base_letters_button(chat_id, 0, context)
 
 


### PR DESCRIPTION
## Summary
- keep base letters message unpinned at round start by unpinning previous messages
- refresh base letters button to keep it last in chat

## Testing
- `pytest`
- `rg pin_chat_message -n`


------
https://chatgpt.com/codex/tasks/task_e_68bd974920148326a7e57135017df885