### PR TITLE
chore: use langchain-openai ChatOpenAI

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,6 +1,6 @@
 """Utilities for querying LLM about Russian words using LangChain."""
 
-from langchain.chat_models import ChatOpenAI
+from langchain_openai import ChatOpenAI
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ fastapi>=0.110
 uvicorn[standard]>=0.30
 langchain>=0.1.0
 openai>=1.0.0
+
+langchain-openai>=0.1.0


### PR DESCRIPTION
## Summary
- use `langchain_openai.ChatOpenAI` instead of deprecated `langchain.chat_models`
- add `langchain-openai` package to requirements

## Testing
- `python -m py_compile llm_utils.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement langchain>=0.1.0)*
- `timeout 5s uvicorn app:app --host 0.0.0.0 --port 8000` *(fails: ModuleNotFoundError: No module named 'langchain_openai')*


------
https://chatgpt.com/codex/tasks/task_e_68c6826e383483269ba2edfb329935ff