### PR TITLE
Ensure name prompt guard only handles commands

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -224,20 +224,23 @@ async def _tap(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def awaiting_name_guard(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
-    """Ensure the user provides a name before other commands."""
+    """Ensure the user provides a name before processing commands."""
     if not context.user_data.get("awaiting_name"):
         return
     message = update.effective_message
-    text = message.text if message and message.text else ""
+    if not message:
+        return
+    text = message.text or ""
+    if not text.startswith("/"):
+        return
     cmd = text.split()[0].split("@")[0]
     if cmd in ("/quit", "/exit"):
         return
-    if message:
-        await reply_game_message(
-            message,
-            context,
-            "Сначала назовитесь. Введите ваше имя:",
-        )
+    await reply_game_message(
+        message,
+        context,
+        "Сначала назовитесь. Введите ваше имя:",
+    )
     raise ApplicationHandlerStop
 
 
@@ -1291,7 +1294,9 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     # 0) «Кран-тик» — логируем все апдейты как можно раньше
     application.add_handler(MessageHandler(filters.ALL, _tap, block=False), group=-2)
     # 1) Guard to require name before other commands
-    application.add_handler(MessageHandler(filters.ALL, awaiting_name_guard), group=-1)
+    application.add_handler(
+        MessageHandler(filters.COMMAND, awaiting_name_guard), group=-1
+    )
     if include_start:
         application.add_handler(CommandHandler("start", start_cmd))
     application.add_handler(CommandHandler("newgame", newgame))

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -298,20 +298,23 @@ async def reply_game_message(message, context: CallbackContext, text: str, **kwa
 async def awaiting_name_guard(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
-    """Ensure the user supplies a name before other actions."""
+    """Ensure the user supplies a name before processing commands."""
     if not context.user_data.get("awaiting_name"):
         return
     message = update.effective_message
-    text = message.text if message and message.text else ""
+    if not message:
+        return
+    text = message.text or ""
+    if not text.startswith("/"):
+        return
     cmd = text.split()[0].split("@")[0]
     if cmd in ("/quit", "/exit"):
         return
-    if message:
-        await reply_game_message(
-            message,
-            context,
-            "Сначала назовитесь. Введите ваше имя:",
-        )
+    await reply_game_message(
+        message,
+        context,
+        "Сначала назовитесь. Введите ваше имя:",
+    )
     raise ApplicationHandlerStop
 
 
@@ -1016,7 +1019,9 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     if include_start:
         application.add_handler(CommandHandler("start", start_cmd))
     # Guard to require players to introduce themselves first
-    application.add_handler(MessageHandler(filters.ALL, awaiting_name_guard), group=-1)
+    application.add_handler(
+        MessageHandler(filters.COMMAND, awaiting_name_guard), group=-1
+    )
     application.add_handler(CommandHandler("newgame", newgame))
     application.add_handler(CommandHandler("join", join_cmd))
     application.add_handler(CommandHandler(["quit", "exit"], quit_cmd))


### PR DESCRIPTION
## Summary
- Limit name-guard handlers to commands in both games
- Let non-command text set player names and clear the awaiting flag

## Testing
- `python -m py_compile compose_word_game/word_game_app.py grebeshok_game/grebeshok_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c684eb584883269182be5ed6a8c8ca