### PR TITLE
Log and categorize LLM responses

### DIFF
--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,8 +1,12 @@
 """Utilities for querying LLM about Russian words using LangChain."""
 
-from langchain_openai import ChatOpenAI
+import logging
+
 from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+
+logger = logging.getLogger(__name__)
 
 
 _prompt = PromptTemplate(
@@ -26,5 +30,17 @@ _chain = LLMChain(llm=_llm, prompt=_prompt)
 
 async def describe_word(word: str) -> str:
     """Return information about a word using the configured LLM chain."""
-    return await _chain.apredict(word=word)
+    logger.info("Querying word: %s", word)
+    result = await _chain.apredict(word=word)
+    lower = result.lower()
+    if "такого слова не существует" in lower:
+        category = "nonexistent"
+    elif "не является существительным" in lower:
+        category = "not_noun"
+    elif "определение:" in lower:
+        category = "noun"
+    else:
+        category = "unknown"
+    logger.info("LLM raw response: %s | category: %s", result, category)
+    return result
 


### PR DESCRIPTION
## Summary
- Add module-level logger in `llm_utils.py`
- Log word queries and raw LLM responses with categorized results

## Testing
- `python -m py_compile llm_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6c1c79c5c8326b632bc28a3fdb68e