### PR TITLE
feat: improve Wiktionary lookup

### DIFF
--- a/tests/data/iny.html
+++ b/tests/data/iny.html
@@ -1,9 +1,10 @@
 <html><body>
-<span id="Существительное_1"></span>
-<span id="Значение_1"></span>
-<div>ignored</div>
+<div id="mw-content-text"><div class="mw-parser-output">
+<h3><span class="mw-headline" id="Существительное">Существительное</span></h3>
+<h4><span class="mw-headline" id="Значение">Значение</span></h4>
 <ol>
 <li>женское начало в китайской философии</li>
 <li>другое значение</li>
 </ol>
+</div></div>
 </body></html>

--- a/tests/data/tol.html
+++ b/tests/data/tol.html
@@ -1,9 +1,9 @@
 <html><body>
-<span id="Существительное_2"></span>
-<span id="Значение_3"></span>
-<p>ignored</p>
+<div id="mw-content-text"><div class="mw-parser-output">
+<h3><span class="mw-headline" id="Существительное">Существительное</span></h3>
 <ol>
 <li>кровельный материал из картона, пропитанного дегтем или битумом</li>
 <li>другое значение</li>
 </ol>
+</div></div>
 </body></html>

--- a/tests/test_lookup_wiktionary.py
+++ b/tests/test_lookup_wiktionary.py
@@ -1,10 +1,13 @@
 import io
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bs4 import BeautifulSoup
 
 import llm_utils
 
@@ -36,15 +39,23 @@ def test_lookup_wiktionary_iny():
     assert definition == 'женское начало в китайской философии'
 
 
-def test_lookup_wiktionary_tol():
+def test_lookup_wiktionary_fallback_no_span(caplog):
     html = load_html('tol')
+    soup = BeautifulSoup(html, 'html.parser')
+    for span in soup.select('span.mw-headline[id^="Существительное"]'):
+        span.decompose()
+    html_no_span = str(soup).encode('utf-8')
 
     def fake_urlopen(url):
-        return DummyResponse(html)
+        return DummyResponse(html_no_span)
 
     with patch('llm_utils.request.urlopen', fake_urlopen):
-        exists, is_noun, definition = llm_utils.lookup_wiktionary('толь')
+        with caplog.at_level(logging.INFO):
+            exists, is_noun, definition = llm_utils.lookup_wiktionary('толь')
 
     assert exists is True
     assert is_noun is True
-    assert definition == 'кровельный материал из картона, пропитанного дегтем или битумом'
+    assert definition == (
+        'кровельный материал из картона, пропитанного дегтем или битумом'
+    )
+    assert any('branch: no_span' in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- enhance Wiktionary lookup with user-agent and granular error handling
- add multiple parsing fallbacks with logging
- cover fallback path in tests with stored HTML samples

## Testing
- `pytest -q` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68c70c685e488326b378eaa272927ba1