### PR TITLE
Lazy LLM chain initialization and test env defaults

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")


### PR DESCRIPTION
## Summary
- avoid ChatOpenAI instantiation at import by adding `get_chain` helper that checks `OPENAI_API_KEY`
- update `describe_word` to fetch LLM chain lazily
- add test `conftest.py` setting a dummy `OPENAI_API_KEY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install -q beautifulsoup4 langchain langchain-openai openai` *(fails: Could not find a version that satisfies the requirement beautifulsoup4)*

------
https://chatgpt.com/codex/tasks/task_e_68c70f5a45c88326a353945ecc673f4e