### PR TITLE
Refresh base prompt after word queries

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1055,7 +1055,7 @@ async def question_word(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         else "Этого слова нет в словаре игры"
     )
     llm_text = await describe_word(word)
-    await message.reply_text(f"{prefix}\n\n{llm_text}")
+    await reply_game_message(message, context, f"{prefix}\n\n{llm_text}")
     raise ApplicationHandlerStop
 
 

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -947,7 +947,7 @@ async def question_word(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         else "Этого слова нет в словаре игры"
     )
     llm_text = await describe_word(word)
-    await message.reply_text(f"{prefix}\n\n{llm_text}")
+    await reply_game_message(message, context, f"{prefix}\n\n{llm_text}")
     raise ApplicationHandlerStop
 
 


### PR DESCRIPTION
## Summary
- Resend the base word or letter prompt after replying to ?word queries so game context stays visible

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install beautifulsoup4 -q` *(fails: Could not find a version that satisfies the requirement due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c71262fca0832698cec97e66947354