### PR TITLE
Use Wiktionary API for definitions

### DIFF
--- a/tests/test_lookup_wiktionary.py
+++ b/tests/test_lookup_wiktionary.py
@@ -1,13 +1,11 @@
 import io
-import logging
+import json
 from pathlib import Path
 from unittest.mock import patch
 
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-from bs4 import BeautifulSoup
 
 import llm_utils
 
@@ -20,42 +18,53 @@ class DummyResponse(io.BytesIO):
         self.close()
 
 
-def load_html(name: str) -> bytes:
-    path = Path(__file__).parent / 'data' / f'{name}.html'
-    return path.read_bytes()
+def make_json(extract: str) -> bytes:
+    data = {"query": {"pages": {"1": {"extract": extract}}}}
+    return json.dumps(data).encode("utf-8")
 
 
 def test_lookup_wiktionary_iny():
-    html = load_html('iny')
+    payload = make_json("женское начало в китайской философии\nдругое")
 
     def fake_urlopen(url):
-        return DummyResponse(html)
+        return DummyResponse(payload)
 
-    with patch('llm_utils.request.urlopen', fake_urlopen):
-        exists, is_noun, definition = llm_utils.lookup_wiktionary('инь')
+    with patch("llm_utils.request.urlopen", fake_urlopen):
+        exists, is_noun, definition = llm_utils.lookup_wiktionary("инь")
 
     assert exists is True
     assert is_noun is True
-    assert definition == 'женское начало в китайской философии'
+    assert definition == "женское начало в китайской философии"
 
 
-def test_lookup_wiktionary_fallback_no_span(caplog):
-    html = load_html('tol')
-    soup = BeautifulSoup(html, 'html.parser')
-    for span in soup.select('span.mw-headline[id^="Существительное"]'):
-        span.decompose()
-    html_no_span = str(soup).encode('utf-8')
+def test_lookup_wiktionary_missing():
+    data = {"query": {"pages": {"-1": {"ns": 0, "title": "foo", "missing": ""}}}}
+    payload = json.dumps(data).encode("utf-8")
 
     def fake_urlopen(url):
-        return DummyResponse(html_no_span)
+        return DummyResponse(payload)
 
-    with patch('llm_utils.request.urlopen', fake_urlopen):
-        with caplog.at_level(logging.INFO):
-            exists, is_noun, definition = llm_utils.lookup_wiktionary('толь')
+    with patch("llm_utils.request.urlopen", fake_urlopen):
+        result = llm_utils.lookup_wiktionary("foo")
 
-    assert exists is True
-    assert is_noun is True
-    assert definition == (
-        'кровельный материал из картона, пропитанного дегтем или битумом'
+    assert result == (False, False, "")
+
+
+def test_lookup_wiktionary_first_line():
+    payload = make_json(
+        "кровельный материал из картона, пропитанного дегтем или битумом\nВторое"
     )
-    assert any('branch: no_span' in record.message for record in caplog.records)
+
+    def fake_urlopen(url):
+        return DummyResponse(payload)
+
+    with patch("llm_utils.request.urlopen", fake_urlopen):
+        exists, is_noun, definition = llm_utils.lookup_wiktionary("толь")
+
+    assert exists is True
+    assert is_noun is True
+    assert (
+        definition
+        == "кровельный материал из картона, пропитанного дегтем или битумом"
+    )
+


### PR DESCRIPTION
## Summary
- replace HTML scraping with MediaWiki API to fetch first definition
- add lazy ChatOpenAI initialization with fallback stub
- update unit tests to mock API JSON responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c82d7e9ef48326bfd7795a290c3428