### PR TITLE
Format question word replies with HTML

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1062,7 +1062,12 @@ async def question_word(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         else "Этого слова нет в словаре игры"
     )
     llm_text = await describe_word(word)
-    await reply_game_message(message, context, f"{prefix}\n\n{llm_text}")
+    await reply_game_message(
+        message,
+        context,
+        f"<b>{word}</b> {prefix}\n\n{llm_text}",
+        parse_mode="HTML",
+    )
     raise ApplicationHandlerStop
 
 

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -947,7 +947,15 @@ async def question_word(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         else "Этого слова нет в словаре игры"
     )
     llm_text = await describe_word(word)
-    await reply_game_message(message, context, f"{prefix}\n\n{llm_text}")
+    text = f"<b>{word}</b> {prefix}"
+    if llm_text:
+        text = f"{text}\n\n{llm_text}"
+    await reply_game_message(
+        message,
+        context,
+        text,
+        parse_mode="HTML",
+    )
     raise ApplicationHandlerStop
 
 


### PR DESCRIPTION
## Summary
- highlight queried words in `question_word` responses and enable HTML parse mode in both games
- preserve dictionary status messaging while continuing to show optional LLM definitions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c84d885fec8326b44534f57caafab6