### PR TITLE
Clear awaiting names on quit

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -688,6 +688,8 @@ async def quit_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     text = f"Игра прервана участником {name}. Вы можете начать заново, нажав /start"
     await reply_game_message(update.message, context, text)
     await broadcast(game.game_id, text, skip_chat_id=chat_id)
+    for user_id in list(game.players.keys()):
+        clear_awaiting_name(context, user_id)
     BASE_MSG_IDS.pop(game.game_id, None)
     for cid in set(game.player_chats.values()):
         CHAT_GAMES.pop((cid, 0), None)

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -336,6 +336,19 @@ async def awaiting_grebeshok_name_guard(
     raise ApplicationHandlerStop
 
 
+def clear_awaiting_grebeshok_name(
+    context: CallbackContext, user_id: int
+) -> None:
+    """Remove awaiting name flags for a player from context storages."""
+    context.user_data.pop("awaiting_grebeshok_name", None)
+    if context.application:
+        user_store = context.application.user_data.get(user_id)
+        if user_store is not None:
+            user_store.pop("awaiting_grebешok_name", None)
+            if not user_store:
+                context.application.user_data.pop(user_id, None)
+
+
 # ---------------------------------------------------------------------------
 # Command and callback handlers
 # ---------------------------------------------------------------------------
@@ -469,6 +482,8 @@ async def quit_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             except Exception:
                 pass
     game.jobs.clear()
+    for member_id in list(game.players.keys()):
+        clear_awaiting_grebeshok_name(context, member_id)
     await broadcast(game, message, context, skip_chat_id=chat_id)
     await reply_game_message(update.message, context, message)
     for cid in list(game.player_chats.values()):


### PR DESCRIPTION
## Summary
- clear stored awaiting-name flags for all players when the compose-word game is quit
- add a helper for Grebeshok to reset awaiting-name state and invoke it during quit handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c932f4df9083268d43d6e74482b86c