### PR TITLE
Specify allowed Telegram updates for webhook

### DIFF
--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -62,6 +62,7 @@ WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "")
 WEBHOOK_PATH = os.environ.get("WEBHOOK_PATH", "/webhook")
 ADMIN_ID = int(os.environ.get("ADMIN_ID", "0"))
 MESSAGE_RATE_LIMIT = float(os.environ.get("MESSAGE_RATE_LIMIT", "1"))
+ALLOWED_UPDATES = ["message", "callback_query"]
 
 
 logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO").upper())
@@ -1143,7 +1144,7 @@ async def on_startup() -> None:
             await APPLICATION.bot.set_webhook(
                 url=webhook_url,
                 secret_token=WEBHOOK_SECRET,
-                allowed_updates=[],
+                allowed_updates=ALLOWED_UPDATES,
             )
 
 
@@ -1161,7 +1162,7 @@ async def webhook_check(context: CallbackContext) -> None:
         await APPLICATION.bot.set_webhook(
             url=webhook_url,
             secret_token=WEBHOOK_SECRET,
-            allowed_updates=[],
+            allowed_updates=ALLOWED_UPDATES,
         )
 
 
@@ -1181,7 +1182,7 @@ async def set_webhook() -> JSONResponse:
     await APPLICATION.bot.set_webhook(
         url=webhook_url,
         secret_token=WEBHOOK_SECRET,
-        allowed_updates=[],
+        allowed_updates=ALLOWED_UPDATES,
     )
     return JSONResponse({"url": webhook_url})
 
@@ -1193,7 +1194,7 @@ async def reset_webhook() -> JSONResponse:
     await APPLICATION.bot.set_webhook(
         url=webhook_url,
         secret_token=WEBHOOK_SECRET,
-        allowed_updates=[],
+        allowed_updates=ALLOWED_UPDATES,
     )
     return JSONResponse({"reset_to": webhook_url})
 


### PR DESCRIPTION
## Summary
- define a shared list of allowed Telegram update types for webhook registration
- use the explicit allowed update list for every set_webhook call to ensure message updates are delivered

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93da2d81083268823fab6a82e9ad1