### PR TITLE
Set handle_name handlers as non-blocking

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1327,7 +1327,7 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     application.add_handler(CommandHandler(["quit", "exit"], quit_cmd))
     application.add_handler(CommandHandler("chatid", chat_id_handler))
     application.add_handler(
-        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name),
+        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=False),
         group=0,
     )
     application.add_handler(CallbackQueryHandler(time_selected, pattern="^(time_|adm_test)"))

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -1130,7 +1130,7 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     application.add_handler(CommandHandler("join", join_cmd))
     application.add_handler(CommandHandler(["quit", "exit"], quit_cmd))
     application.add_handler(
-        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name),
+        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=False),
         group=0,
     )
     application.add_handler(


### PR DESCRIPTION
## Summary
- set the handle_name text message handler to be non-blocking in both games

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c949ebb4c48326ac4856902a244698