### PR TITLE
Implement shared /quit command across games

### DIFF
--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -1128,7 +1128,7 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     )
     application.add_handler(CommandHandler("newgame", newgame))
     application.add_handler(CommandHandler("join", join_cmd))
-    application.add_handler(CommandHandler(["quit", "exit"], quit_cmd))
+    application.add_handler(CommandHandler("exit", quit_cmd))
     application.add_handler(
         MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=False),
         group=0,


### PR DESCRIPTION
## Summary
- add a shared `/quit` handler in `app.py` that forwards the command to the running game or notifies when no game is active
- remove the per-game `/quit` registrations so the global command is unambiguous while keeping `/exit`
- harden the compose game name-tracking helpers to tolerate plain dict `user_data` containers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95fdd768883268535c1a890e0b8de