### PR TITLE
Adjust handler blocking for name and gameplay flows

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1340,8 +1340,8 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     application.add_handler(CommandHandler("exit", quit_cmd))
     application.add_handler(CommandHandler("chatid", chat_id_handler))
     application.add_handler(
-        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=False),
-        group=0,
+        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=True),
+        group=-1,
     )
     application.add_handler(CallbackQueryHandler(time_selected, pattern="^(time_|adm_test)"))
     application.add_handler(CallbackQueryHandler(join_button, pattern="^join_"))

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -1130,8 +1130,8 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     application.add_handler(CommandHandler("join", join_cmd))
     application.add_handler(CommandHandler("exit", quit_cmd))
     application.add_handler(
-        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=False),
-        group=0,
+        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_name, block=True),
+        group=-1,
     )
     application.add_handler(
         MessageHandler(filters.Regex("^Создать ссылку$"), invite_link),
@@ -1144,6 +1144,7 @@ def register_handlers(application: Application, include_start: bool = False) -> 
         MessageHandler(
             filters.ChatType.PRIVATE & filters.Regex(r'^\?'),
             question_word,
+            block=False,
         ),
         group=1,
     )
@@ -1153,7 +1154,7 @@ def register_handlers(application: Application, include_start: bool = False) -> 
     application.add_handler(CallbackQueryHandler(start_round_cb, pattern="^start_round$"))
     application.add_handler(CallbackQueryHandler(restart_game, pattern="^restart_"))
     application.add_handler(
-        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_word),
+        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_word, block=False),
         group=1,
     )
 


### PR DESCRIPTION
## Summary
- ensure `handle_name` handlers run in group -1 with blocking in both games so name collection halts the pipeline
- keep gameplay text handlers such as `question_word` and `handle_word` in group 1 with `block=False` to preserve non-blocking processing

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c99eca89f48326bb381cab4db87cc0