### PR TITLE
Register host chat in CHAT_GAMES when creating new games

### DIFF
--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -392,6 +392,7 @@ async def newgame(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     host_id = update.effective_user.id
     game = GameState(host_id=host_id)
+    CHAT_GAMES[chat.id] = game
     game.players[host_id] = Player(user_id=host_id)
     game.player_chats[host_id] = chat.id
     ACTIVE_GAMES[gid] = game


### PR DESCRIPTION
## Summary
- register the host's private chat in `CHAT_GAMES` when `/newgame` creates a new `GameState`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a0cc92608326b4a0725e210e7c0d