### PR TITLE
Add awaiting-name filters for compose and grebeshok games

### DIFF
--- a/tests/test_word_game_app.py
+++ b/tests/test_word_game_app.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock, patch
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from compose_word_game import word_game_app as app
-from telegram.ext import ApplicationHandlerStop
+from grebeshok_game import grebeshok_app as greb_app
+from telegram.ext import Application, ApplicationHandlerStop
 
 
 class DummyMessage:
@@ -161,3 +162,170 @@ def test_handle_name_uses_application_storage_when_user_data_empty():
             app.CHAT_GAMES.update(old_chat_games)
 
     asyncio.run(run())
+
+
+def test_compose_and_grebeshok_name_filters_isolated():
+    async def run(compose_first: bool) -> None:
+        compose_active = app.ACTIVE_GAMES.copy()
+        compose_join = app.JOIN_CODES.copy()
+        compose_base_ids = app.BASE_MSG_IDS.copy()
+        compose_refresh = app.LAST_REFRESH.copy()
+        compose_chat_games = app.CHAT_GAMES.copy()
+        compose_awaiting = app.AWAITING_NAME_USERS.copy()
+        old_compose_app = app.APPLICATION
+
+        greb_active = greb_app.ACTIVE_GAMES.copy()
+        greb_chat_games = greb_app.CHAT_GAMES.copy()
+        greb_join = greb_app.JOIN_CODES.copy()
+        greb_finished = greb_app.FINISHED_GAMES.copy()
+        greb_base_ids = greb_app.BASE_MSG_IDS.copy()
+        greb_refresh = greb_app.LAST_REFRESH.copy()
+        greb_locks = greb_app.REFRESH_LOCKS.copy()
+        greb_awaiting = greb_app.AWAITING_GREBESHOK_NAME_USERS.copy()
+        old_greb_app = greb_app.APPLICATION
+
+        try:
+            app.ACTIVE_GAMES.clear()
+            app.JOIN_CODES.clear()
+            app.BASE_MSG_IDS.clear()
+            app.LAST_REFRESH.clear()
+            app.CHAT_GAMES.clear()
+            app.AWAITING_NAME_USERS.clear()
+
+            greb_app.ACTIVE_GAMES.clear()
+            greb_app.CHAT_GAMES.clear()
+            greb_app.JOIN_CODES.clear()
+            greb_app.FINISHED_GAMES.clear()
+            greb_app.BASE_MSG_IDS.clear()
+            greb_app.LAST_REFRESH.clear()
+            greb_app.REFRESH_LOCKS.clear()
+            greb_app.AWAITING_GREBESHOK_NAME_USERS.clear()
+
+            application = Application.builder().token("123:ABC").build()
+
+            with patch.object(app, "schedule_refresh_base_button", lambda *a, **kw: None), patch.object(
+                greb_app, "schedule_refresh_base_letters", lambda *a, **kw: None
+            ):
+                if compose_first:
+                    app.register_handlers(application)
+                    greb_app.register_handlers(application)
+                else:
+                    greb_app.register_handlers(application)
+                    app.register_handlers(application)
+
+                # Avoid network calls in broadcast helpers
+                app.APPLICATION = None
+                greb_app.APPLICATION = None
+
+                shared_application = SimpleNamespace(user_data={})
+                compose_bot = SimpleNamespace(
+                    send_message=AsyncMock(return_value=SimpleNamespace(message_id=1))
+                )
+                greb_bot = SimpleNamespace(
+                    send_message=AsyncMock(return_value=SimpleNamespace(message_id=1))
+                )
+
+                compose_context = SimpleNamespace(
+                    args=[],
+                    user_data={},
+                    application=shared_application,
+                    bot=compose_bot,
+                )
+                greb_context = SimpleNamespace(
+                    args=[],
+                    user_data={},
+                    application=shared_application,
+                    bot=greb_bot,
+                )
+
+                greb_user = 501
+                greb_message = DummyMessage(greb_user, greb_user, text="/newgame")
+                greb_update = SimpleNamespace(
+                    effective_user=SimpleNamespace(id=greb_user),
+                    effective_chat=greb_message.chat,
+                    effective_message=greb_message,
+                    message=greb_message,
+                )
+
+                compose_user = 601
+                compose_message = DummyMessage(compose_user, compose_user, text="/start")
+                compose_update = SimpleNamespace(
+                    effective_user=SimpleNamespace(id=compose_user),
+                    effective_chat=compose_message.chat,
+                    effective_message=compose_message,
+                    message=compose_message,
+                )
+
+                await greb_app.newgame(greb_update, greb_context)
+                assert greb_user in greb_app.AWAITING_GREBESHOK_NAME_USERS
+                assert (
+                    shared_application.user_data.get(greb_user, {}).get("awaiting_grebeshok_name")
+                    is True
+                )
+                assert compose_user not in greb_app.AWAITING_GREBESHOK_NAME_USERS
+
+                await app.start_cmd(compose_update, compose_context)
+                assert compose_user in app.AWAITING_NAME_USERS
+                assert (
+                    shared_application.user_data.get(compose_user, {}).get("awaiting_name") is True
+                )
+                assert greb_user not in app.AWAITING_NAME_USERS
+
+                greb_message.text = "Глеб"
+                try:
+                    await greb_app.handle_name(greb_update, greb_context)
+                except ApplicationHandlerStop:
+                    pass
+
+                assert greb_user not in greb_app.AWAITING_GREBESHOK_NAME_USERS
+                assert "awaiting_grebeshok_name" not in shared_application.user_data.get(
+                    greb_user, {}
+                )
+                assert compose_user in app.AWAITING_NAME_USERS
+                assert any("Имя установлено" in reply[0] for reply in greb_message.replies)
+
+                compose_message.text = "Алиса"
+                try:
+                    await app.handle_name(compose_update, compose_context)
+                except ApplicationHandlerStop:
+                    pass
+
+                assert compose_user not in app.AWAITING_NAME_USERS
+                assert "awaiting_name" not in shared_application.user_data.get(compose_user, {})
+                assert greb_user not in greb_app.AWAITING_GREBESHOK_NAME_USERS
+                assert any("Имя установлено" in reply[0] for reply in compose_message.replies)
+        finally:
+            app.ACTIVE_GAMES.clear()
+            app.ACTIVE_GAMES.update(compose_active)
+            app.JOIN_CODES.clear()
+            app.JOIN_CODES.update(compose_join)
+            app.BASE_MSG_IDS.clear()
+            app.BASE_MSG_IDS.update(compose_base_ids)
+            app.LAST_REFRESH.clear()
+            app.LAST_REFRESH.update(compose_refresh)
+            app.CHAT_GAMES.clear()
+            app.CHAT_GAMES.update(compose_chat_games)
+            app.AWAITING_NAME_USERS.clear()
+            app.AWAITING_NAME_USERS.update(compose_awaiting)
+            app.APPLICATION = old_compose_app
+
+            greb_app.ACTIVE_GAMES.clear()
+            greb_app.ACTIVE_GAMES.update(greb_active)
+            greb_app.CHAT_GAMES.clear()
+            greb_app.CHAT_GAMES.update(greb_chat_games)
+            greb_app.JOIN_CODES.clear()
+            greb_app.JOIN_CODES.update(greb_join)
+            greb_app.FINISHED_GAMES.clear()
+            greb_app.FINISHED_GAMES.update(greb_finished)
+            greb_app.BASE_MSG_IDS.clear()
+            greb_app.BASE_MSG_IDS.update(greb_base_ids)
+            greb_app.LAST_REFRESH.clear()
+            greb_app.LAST_REFRESH.update(greb_refresh)
+            greb_app.REFRESH_LOCKS.clear()
+            greb_app.REFRESH_LOCKS.update(greb_locks)
+            greb_app.AWAITING_GREBESHOK_NAME_USERS.clear()
+            greb_app.AWAITING_GREBESHOK_NAME_USERS.update(greb_awaiting)
+            greb_app.APPLICATION = old_greb_app
+
+    asyncio.run(run(True))
+    asyncio.run(run(False))


### PR DESCRIPTION
## Summary
- add a shared awaiting-name set and message filter for the compose game so the name handler only triggers when a name is pending
- mirror the awaiting-name tracking/filtering for the grebeshok game and update mark/clear helpers
- add an integration-style regression test that registers both modules on one Application and verifies name prompts go to the correct game

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c27842948326b04bad50ea79fe3a