### PR TITLE
Ensure blank line before winner announcement

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1069,6 +1069,8 @@ async def end_game(context: CallbackContext) -> None:
         lines.append("")
 
     if winners:
+        if not lines or lines[-1] != "":
+            lines.append("")
         if len(winners) == 1:
             lines.append(
                 f"🏆 <b>Победитель:</b> {html.escape(format_name(winners[0]))}"

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -1033,12 +1033,11 @@ async def finish_game(game: GameState, context: CallbackContext, reason: str) ->
             lines.append(f"{i}. {html.escape(w)}")
         lines.append(f"<b>Итог:</b> {p.points}")
         lines.append("")
-    if lines and lines[-1] == "":
-        lines.pop()
-
     max_points = players_sorted[0].points if players_sorted else 0
     winners = [p for p in players_sorted if p.points == max_points]
     if winners:
+        if not lines or lines[-1] != "":
+            lines.append("")
         if len(winners) == 1:
             lines.append(
                 f"🏆 <b>Победитель:</b> {html.escape(format_player_name(winners[0]))}"
@@ -1048,6 +1047,8 @@ async def finish_game(game: GameState, context: CallbackContext, reason: str) ->
                 "🏆 <b>Победители:</b> "
                 + ", ".join(html.escape(format_player_name(p)) for p in winners)
             )
+    elif lines and lines[-1] == "":
+        lines.pop()
 
     text = "\n".join(lines).rstrip()
     await broadcast(game, text, context, parse_mode="HTML")


### PR DESCRIPTION
## Summary
- add an explicit blank line before the winner announcement in the Compose Word Game results summary
- ensure the Grebeshok game results output also inserts a blank line before the winner line while avoiding trailing blanks when no winner is shown

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda3c8f8288326adadbcae8fdc25f0