### PR TITLE
Adjust stats ordering and copy in post-game summaries

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1104,11 +1104,11 @@ def build_compose_stats_message(
 
     lines = ["✨ <b>Интересная статистика</b>", ""]
 
-    lines.append("📊 <b>Длинные слова</b>")
+    lines.append("🏅 <b>Лидеры по длинным словам (6 и более букв):</b>")
     if long_word_counts:
         for player, count in long_word_counts:
             lines.append(
-                f"• {html.escape(format_name(player))} — {count}"
+                f"• {html.escape(format_name(player))} — {count} шт."
             )
     else:
         lines.append("Нет слов длиной 6+ букв.")
@@ -1125,12 +1125,11 @@ def build_compose_stats_message(
         lines.append("Нет данных о самых длинных словах.")
     lines.append("")
 
-    lines.append("🪄 <b>Самое редкое слово</b>")
+    lines.append("🏅 <b>Самое редкое слово</b>")
     if rarest:
         zipf, _, player, word = rarest
         lines.append(
             f"• {html.escape(word)} — {html.escape(format_name(player))}"
-            f" (Zipf {zipf:.3f})"
         )
     else:
         lines.append("Нет данных о редкости слов.")
@@ -1197,6 +1196,9 @@ async def end_game(context: CallbackContext) -> None:
                 + ", ".join(html.escape(format_name(p)) for p in winners)
             )
     message = "\n".join(lines).rstrip()
+    await broadcast(game.game_id, message, parse_mode="HTML")
+    stats_message = build_compose_stats_message(game, format_name)
+    await broadcast(game.game_id, stats_message, parse_mode="HTML")
     keyboard = InlineKeyboardMarkup(
         [
             [
@@ -1212,10 +1214,11 @@ async def end_game(context: CallbackContext) -> None:
         ]
     )
     await broadcast(
-        game.game_id, message, reply_markup=keyboard, parse_mode="HTML"
+        game.game_id,
+        "Выберите, как продолжить игру:",
+        reply_markup=keyboard,
+        parse_mode="HTML",
     )
-    stats_message = build_compose_stats_message(game, format_name)
-    await broadcast(game.game_id, stats_message, parse_mode="HTML")
     choice_handle = game.jobs.pop("base_choice", None)
     if isinstance(choice_handle, ChoiceTimerHandle):
         await choice_handle.complete(final_timer_text=None)

--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -1110,12 +1110,11 @@ def build_grebeshok_stats_message(game: GameState) -> str:
         lines.append("Нет данных по базовым буквам.")
     lines.append("")
 
-    lines.append("🪄 <b>Самое редкое слово</b>")
+    lines.append("🏅 <b>Самое редкое слово</b>")
     if rarest:
         zipf, _, player, word = rarest
         lines.append(
             f"• {html.escape(word)} — {html.escape(format_player_name(player))}"
-            f" (Zipf {zipf:.3f})"
         )
     else:
         lines.append("Нет данных о редкости слов.")

--- a/tests/test_word_game_app.py
+++ b/tests/test_word_game_app.py
@@ -367,11 +367,11 @@ def test_compose_end_game_sends_stats_message():
             ):
                 await app.end_game(context)
 
-            assert broadcast_mock.await_count == 2
+            assert broadcast_mock.await_count == 3
             stats_call = broadcast_mock.await_args_list[1]
             _, stats_text = stats_call.args[:2]
-            assert "📊 <b>Длинные слова</b>" in stats_text
-            assert "Алиса" in stats_text and "2" in stats_text
+            assert "🏅 <b>Лидеры по длинным словам (6 и более букв):</b>" in stats_text
+            assert "Алиса" in stats_text and "2 шт." in stats_text
             assert "самолет" in stats_text
             assert "самовар" in stats_text
         finally:
@@ -413,7 +413,7 @@ def test_compose_stats_handle_empty_data():
             ):
                 await app.end_game(context)
 
-            assert broadcast_mock.await_count == 2
+            assert broadcast_mock.await_count == 3
             stats_text = broadcast_mock.await_args_list[1].args[1]
             assert "Нет слов длиной 6+ букв" in stats_text
             assert "Нет данных о самых длинных словах" in stats_text


### PR DESCRIPTION
## Summary
- update the compose game stats block to use the new copy and remove Zipf frequency values
- send the post-game restart buttons after the stats message
- align Grebeshok rare word heading emoji and remove Zipf value; refresh tests for the new flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d84bda4ed48326961cab531563cf3d