### PR TITLE
Fix Grebeshok awaiting name reset timing

### DIFF
--- a/grebeshok_game/grebeshok_app.py
+++ b/grebeshok_game/grebeshok_app.py
@@ -577,6 +577,19 @@ async def reset_for_chat(chat_id: int, user_id: int, context: CallbackContext) -
         if key[0] == chat_id or chat_id in game.player_chats.values() or user_id in game.players:
             finished_keys.add(key)
 
+    players_to_clear: Set[int] = set()
+    for key in active_keys:
+        game = ACTIVE_GAMES.get(key)
+        if game:
+            players_to_clear.update(game.players.keys())
+    for key in finished_keys:
+        game = FINISHED_GAMES.get(key)
+        if game:
+            players_to_clear.update(game.players.keys())
+
+    for pid in players_to_clear:
+        clear_awaiting_grebeshok_name(context, pid)
+
     for key in list(active_keys):
         game = ACTIVE_GAMES.get(key)
         if not game:
@@ -600,9 +613,6 @@ async def reset_for_chat(chat_id: int, user_id: int, context: CallbackContext) -
                     except Exception:
                         pass
         game.jobs.clear()
-
-        for pid in list(game.players.keys()):
-            clear_awaiting_grebeshok_name(context, pid)
 
         related_chats = set(game.player_chats.values())
         related_keys = set(game.base_msg_counts.keys())
@@ -631,9 +641,6 @@ async def reset_for_chat(chat_id: int, user_id: int, context: CallbackContext) -
         game = FINISHED_GAMES.pop(key, None)
         if not game:
             continue
-
-        for pid in list(game.players.keys()):
-            clear_awaiting_grebeshok_name(context, pid)
 
         related_chats = set(game.player_chats.values())
         related_keys = set(game.base_msg_counts.keys())

--- a/tests/test_word_game_app.py
+++ b/tests/test_word_game_app.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import app as root_app
 from compose_word_game import word_game_app as app
 from grebeshok_game import grebeshok_app as greb_app
 from telegram.ext import Application, ApplicationHandlerStop
@@ -23,6 +24,21 @@ class DummyMessage:
     async def reply_text(self, text: str, **kwargs):
         self.replies.append((text, kwargs))
         return SimpleNamespace(message_id=1)
+
+
+class DummyCallbackQuery:
+    def __init__(self, data: str, message: DummyMessage, user_id: int) -> None:
+        self.data = data
+        self.message = message
+        self.from_user = SimpleNamespace(id=user_id)
+        self.answered = False
+        self.deleted = False
+
+    async def answer(self, *args, **kwargs):
+        self.answered = True
+
+    async def delete_message(self):
+        self.deleted = True
 
 
 def test_start_then_handle_name_clears_flag():
@@ -329,6 +345,149 @@ def test_compose_and_grebeshok_name_filters_isolated():
 
     asyncio.run(run(True))
     asyncio.run(run(False))
+
+
+def test_choose_grebeshok_then_set_name_replies_with_confirmation():
+    async def run():
+        compose_active = app.ACTIVE_GAMES.copy()
+        compose_join = app.JOIN_CODES.copy()
+        compose_base_ids = app.BASE_MSG_IDS.copy()
+        compose_refresh = app.LAST_REFRESH.copy()
+        compose_chat_games = app.CHAT_GAMES.copy()
+        compose_awaiting = app.AWAITING_NAME_USERS.copy()
+        old_compose_app = app.APPLICATION
+
+        greb_active = greb_app.ACTIVE_GAMES.copy()
+        greb_chat_games = greb_app.CHAT_GAMES.copy()
+        greb_join = greb_app.JOIN_CODES.copy()
+        greb_finished = greb_app.FINISHED_GAMES.copy()
+        greb_base_ids = greb_app.BASE_MSG_IDS.copy()
+        greb_refresh = greb_app.LAST_REFRESH.copy()
+        greb_locks = greb_app.REFRESH_LOCKS.copy()
+        greb_awaiting = greb_app.AWAITING_GREBESHOK_NAME_USERS.copy()
+        old_greb_app = greb_app.APPLICATION
+
+        registered_snapshot = root_app.REGISTERED_GAMES.copy()
+        application_snapshot = root_app.APPLICATION
+
+        try:
+            app.ACTIVE_GAMES.clear()
+            app.JOIN_CODES.clear()
+            app.BASE_MSG_IDS.clear()
+            app.LAST_REFRESH.clear()
+            app.CHAT_GAMES.clear()
+            app.AWAITING_NAME_USERS.clear()
+
+            greb_app.ACTIVE_GAMES.clear()
+            greb_app.CHAT_GAMES.clear()
+            greb_app.JOIN_CODES.clear()
+            greb_app.FINISHED_GAMES.clear()
+            greb_app.BASE_MSG_IDS.clear()
+            greb_app.LAST_REFRESH.clear()
+            greb_app.REFRESH_LOCKS.clear()
+            greb_app.AWAITING_GREBESHOK_NAME_USERS.clear()
+
+            root_app.REGISTERED_GAMES.clear()
+            root_app.APPLICATION = Application.builder().token("123:ABC").build()
+
+            shared_application = SimpleNamespace(user_data={})
+            bot = SimpleNamespace(
+                send_message=AsyncMock(return_value=SimpleNamespace(message_id=1))
+            )
+            context = SimpleNamespace(
+                args=[],
+                user_data={},
+                application=shared_application,
+                bot=bot,
+            )
+
+            user_id = 707
+            chat_id = 808
+            start_message = DummyMessage(chat_id, user_id, text="/start")
+            start_update = SimpleNamespace(
+                message=start_message,
+                effective_message=start_message,
+                effective_chat=start_message.chat,
+                effective_user=SimpleNamespace(id=user_id),
+            )
+
+            await root_app.start(start_update, context)
+
+            query = DummyCallbackQuery("game_grebeshok", start_message, user_id)
+            callback_update = SimpleNamespace(
+                callback_query=query,
+                effective_chat=start_message.chat,
+                effective_user=SimpleNamespace(id=user_id),
+                effective_message=start_message,
+                message=None,
+            )
+
+            name_message = DummyMessage(chat_id, user_id, text="Глеб")
+
+            with (
+                patch.object(app, "schedule_refresh_base_button", lambda *a, **kw: None),
+                patch.object(
+                    greb_app, "schedule_refresh_base_letters", lambda *a, **kw: None
+                ),
+            ):
+                await root_app.choose_game(callback_update, context)
+
+                assert user_id in greb_app.AWAITING_GREBESHOK_NAME_USERS
+                assert context.user_data.get("awaiting_grebeshok_name") is True
+
+                name_update = SimpleNamespace(
+                    effective_user=SimpleNamespace(id=user_id),
+                    effective_chat=name_message.chat,
+                    effective_message=name_message,
+                    message=name_message,
+                )
+
+                try:
+                    await greb_app.handle_name(name_update, context)
+                except ApplicationHandlerStop:
+                    pass
+
+            assert any(
+                "Имя установлено" in reply[0] for reply in name_message.replies
+            )
+        finally:
+            app.ACTIVE_GAMES.clear()
+            app.ACTIVE_GAMES.update(compose_active)
+            app.JOIN_CODES.clear()
+            app.JOIN_CODES.update(compose_join)
+            app.BASE_MSG_IDS.clear()
+            app.BASE_MSG_IDS.update(compose_base_ids)
+            app.LAST_REFRESH.clear()
+            app.LAST_REFRESH.update(compose_refresh)
+            app.CHAT_GAMES.clear()
+            app.CHAT_GAMES.update(compose_chat_games)
+            app.AWAITING_NAME_USERS.clear()
+            app.AWAITING_NAME_USERS.update(compose_awaiting)
+            app.APPLICATION = old_compose_app
+
+            greb_app.ACTIVE_GAMES.clear()
+            greb_app.ACTIVE_GAMES.update(greb_active)
+            greb_app.CHAT_GAMES.clear()
+            greb_app.CHAT_GAMES.update(greb_chat_games)
+            greb_app.JOIN_CODES.clear()
+            greb_app.JOIN_CODES.update(greb_join)
+            greb_app.FINISHED_GAMES.clear()
+            greb_app.FINISHED_GAMES.update(greb_finished)
+            greb_app.BASE_MSG_IDS.clear()
+            greb_app.BASE_MSG_IDS.update(greb_base_ids)
+            greb_app.LAST_REFRESH.clear()
+            greb_app.LAST_REFRESH.update(greb_refresh)
+            greb_app.REFRESH_LOCKS.clear()
+            greb_app.REFRESH_LOCKS.update(greb_locks)
+            greb_app.AWAITING_GREBESHOK_NAME_USERS.clear()
+            greb_app.AWAITING_GREBESHOK_NAME_USERS.update(greb_awaiting)
+            greb_app.APPLICATION = old_greb_app
+
+            root_app.REGISTERED_GAMES.clear()
+            root_app.REGISTERED_GAMES.update(registered_snapshot)
+            root_app.APPLICATION = application_snapshot
+
+    asyncio.run(run())
 
 
 def test_compose_end_game_sends_stats_message():


### PR DESCRIPTION
## Summary
- ensure `reset_for_chat` clears awaiting-name flags before running asynchronous cleanup
- add a regression test that covers the `/start` → Grebeshok selection → name entry flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d85467ff5c832684bb1ff4efff2428