### PR TITLE
Handle restart callbacks after game removal

### DIFF
--- a/compose_word_game/word_game_app.py
+++ b/compose_word_game/word_game_app.py
@@ -1273,8 +1273,11 @@ async def restart_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await query.answer()
     chat_id = query.message.chat.id
     thread_id = query.message.message_thread_id
+    final_text = "Игра завершена. Для новой игры с новыми участниками нажмите /start"
     game = get_game(chat_id, thread_id or 0)
     if not game:
+        if query.data == "restart_no":
+            await query.edit_message_text(final_text)
         return
     if query.data == "restart_yes":
         await reset_game(game)
@@ -1295,9 +1298,7 @@ async def restart_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             reply_markup=InlineKeyboardMarkup(buttons),
         )
     else:
-        text = (
-            "Игра завершена. Для новой игры с новыми участниками нажмите /start"
-        )
+        text = final_text
         await query.edit_message_text(text)
         BASE_MSG_IDS.pop(game.game_id, None)
         sent: Set[int] = set()


### PR DESCRIPTION
## Summary
- ensure the restart handler still responds when the game state has already been removed
- reuse the final restart message text and keep inline keyboards cleared on repeated taps
- extend the test suite with coverage for repeated "restart_no" callbacks

## Testing
- pytest tests/test_word_game_app.py::test_restart_handler_handles_repeated_restart_no_callbacks

------
https://chatgpt.com/codex/tasks/task_e_68d9217f0ef88326bc8b03b1e94627ff